### PR TITLE
Fix ScalingCarousel on Device Rotation

### DIFF
--- a/Example/ScalingCarousel/CodeViewController.swift
+++ b/Example/ScalingCarousel/CodeViewController.swift
@@ -16,6 +16,13 @@ class CodeCell: ScalingCarouselCell {
         
         mainView = UIView(frame: contentView.bounds)
         contentView.addSubview(mainView)
+        mainView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            mainView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            mainView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            mainView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            mainView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/Example/ScalingCarousel/CodeViewController.swift
+++ b/Example/ScalingCarousel/CodeViewController.swift
@@ -47,6 +47,13 @@ class CodeViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+         if scalingCarousel != nil {
+            scalingCarousel.deviceRotated()
+         }
+    }
     
     // MARK: - Configuration
     
@@ -83,7 +90,11 @@ extension CodeViewController: UICollectionViewDataSource {
         if let scalingCell = cell as? ScalingCarouselCell {
             scalingCell.mainView.backgroundColor = .blue
         }
-        
+        DispatchQueue.main.async {
+            cell.setNeedsLayout()
+            cell.layoutIfNeeded()
+        }
+
         return cell
     }
 }

--- a/Example/ScalingCarousel/Info.plist
+++ b/Example/ScalingCarousel/Info.plist
@@ -23,8 +23,6 @@
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-	</array>
+	<array/>
 </dict>
 </plist>

--- a/Example/ScalingCarousel/StoryboardViewController.swift
+++ b/Example/ScalingCarousel/StoryboardViewController.swift
@@ -30,7 +30,11 @@ class StoryboardViewController: UIViewController {
         
         carouselBottomConstraint.constant = Constants.carouselHideConstant
     }
-    
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        carousel.deviceRotated()
+    }
     // MARK: - Button Actions
     
     @IBAction func showHideButtonPressed(_ sender: Any) {
@@ -55,6 +59,11 @@ extension CarouselDatasource: UICollectionViewDataSource {
         
         if let scalingCell = cell as? ScalingCarouselCell {
             scalingCell.mainView.backgroundColor = .red
+        }
+
+        DispatchQueue.main.async {
+            cell.setNeedsLayout()
+            cell.layoutIfNeeded()
         }
         
         return cell

--- a/README.md
+++ b/README.md
@@ -96,11 +96,14 @@ scalingCarousel.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isAc
 cell.setNeedsLayout()
 cell.layoutIfNeeded()
 ```
-* Note: To ensure correct displayed of the ScalingCarousel, you need to call the following code in the method  `viewWillTransition(to size:, with coordinator:)` of the ViewController:
+* Note: To ensure correct displayed of the ScalingCarousel, you need to call the following code in the method  `viewWillTransition(to size:, with coordinator:)` of the ViewController, If you have created the ScalingCarousel by code in the viewDidLoad, It is important to verify that it exists when the method `viewWillTransition` is called or we will have a crash if we load the viewController with the device in landscape mode:
 
 ```
 super.viewWillTransition(to: size, with: coordinator)
-scalingCarousel.deviceRotated()
+if scalingCarousel != nil {
+    scalingCarousel.deviceRotated()
+}
+
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ This property is declared in ScalingCarouselCell. You should add any cell conten
 cell.setNeedsLayout()
 cell.layoutIfNeeded()
 ```
+* Note: To ensure correct displayed of the ScalingCarousel, you need to call the following code in the method  `viewWillTransition(to size:, with coordinator:)` of the ViewController:
+
+```
+super.viewWillTransition(to: size, with: coordinator)
+scalingCarousel.deviceRotated()
+```
 
 ### Code
 
@@ -50,6 +56,13 @@ override init(frame: CGRect) {
   // Initialize the mainView property and add it to the cell's contentView
   mainView = UIView(frame: contentView.bounds)
   contentView.addSubview(mainView)
+  mainView.translatesAutoresizingMaskIntoConstraints = false
+  NSLayoutConstraint.activate([
+      mainView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      mainView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+      mainView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      mainView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+  ])
 }
 ```
 
@@ -82,6 +95,12 @@ scalingCarousel.topAnchor.constraint(equalTo: view.topAnchor, constant: 50).isAc
 ```
 cell.setNeedsLayout()
 cell.layoutIfNeeded()
+```
+* Note: To ensure correct displayed of the ScalingCarousel, you need to call the following code in the method  `viewWillTransition(to size:, with coordinator:)` of the ViewController:
+
+```
+super.viewWillTransition(to: size, with: coordinator)
+scalingCarousel.deviceRotated()
 ```
 
 ## Example

--- a/ScalingCarousel.podspec
+++ b/ScalingCarousel.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ScalingCarousel'
-  s.version          = '2.2'
+  s.version          = '2.3'
   s.summary          = 'A super simple carousel view with scaling transitions written in Swift'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Fixed cells layout when the device is rotated, also when the device rotated, it couldn't get the current center cell, so we can track the last one with a variable and when after the rotation if it doesn't know which one is the current cell we take the value from the stored variable. We update the variable when the scroll ends or when we call programmatically to `scrollToItem`.

Also bumped pod version to 2.3