### PR TITLE
Fixed issue where accessing the current cell would fail on an iPhone 11

### DIFF
--- a/ScalingCarousel/Classes/ScalingCarouselView.swift
+++ b/ScalingCarousel/Classes/ScalingCarouselView.swift
@@ -44,7 +44,7 @@ open class ScalingCarouselView: UICollectionView {
             
             let cellRect = convert(cell.frame, to: nil)
             
-            if cellRect.origin.x > lowerBound && cellRect.origin.x < upperBound {
+            if cellRect.origin.x >= lowerBound && cellRect.origin.x <= upperBound {
                 return cell
             }
             


### PR DESCRIPTION
The `currentCenterCell` accessor returns `nil` on an iPhone 11, on debugging it turns out that the bounds check should be >= / <=

